### PR TITLE
ERROR [Deprecated]: Methods with the same name

### DIFF
--- a/code/Model/MCAPI.class.php
+++ b/code/Model/MCAPI.class.php
@@ -61,7 +61,7 @@ class MCAPI {
      * @param string $apikey Your MailChimp apikey
      * @param string $secure Whether or not this should use a secure connection
      */
-    function MCAPI($apikey, $secure=false) {
+    function __constructor($apikey, $secure=false) {
         $this->secure = $secure;
         $this->apiUrl = parse_url("http://api.mailchimp.com/" . $this->version . "/?output=php");
         $this->api_key = $apikey;


### PR DESCRIPTION
Fix the error methods with the same name as their class will not be constructors in a future version of PHP; MCAPI has a deprecated constructor
IN POST /mailchimp/UpdateLists
Line 28 in /source/mailchimp-module/code/Model/MCAPI.class.php